### PR TITLE
Add gnuplot support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           key: $${{ hashFiles('Makefile') }}
 
       - name: Build code
-        run: make deploy -j$(nproc)
+        run: make deploy -j$(nproc) RELEASE=1
 
       - name: Deploy to GitHub Pages
         if: success()

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "singleQuote": true,
+    "tabWidth": 4,
+    "arrowParens": "always"
+}
+

--- a/Makefile
+++ b/Makefile
@@ -15,73 +15,65 @@ LIBDIR := lib/install/lib
 LIBNAMES := gmp mpfr xml2 qalculate
 libreqs = $(call libfiles,$($(1)_REQS))
 
-QALCULATE_VER = 3.15.0
+QALCULATE_VER := 3.15.0
+# QALCULATE_CHKSUM := sha-256=ed6752cdc6fe6ffc444844e130820d720feba746f98447259117102f6196b216
 QALCULATE_REQS := gmp mpfr xml2
+# QALCULATE_URL = https://github.com/Qalculate/libqalculate/releases/download/v$(1)/libqalculate-$(1).tar.gz
+QALCULATE_URL = https://github.com/coolreader18/libqalculate/archive/byo-gnuplot.tar.gz
 
-EMSDK_VER = 2.0.11
-EMSDK_CHKSUM = sha-256=f366c569d10b5eedf56edab86f4e834ca3a5ca0bf4f9ab1818d8575afd10277b
+EMSDK_VER := 2.0.11
+EMSDK_CHKSUM := sha-256=f366c569d10b5eedf56edab86f4e834ca3a5ca0bf4f9ab1818d8575afd10277b
+EMSDK_URL = https://github.com/emscripten-core/emsdk/archive/$(1).tar.gz
 
-GMP_VER = 6.2.1
-GMP_CHKSUM = sha-256=fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2
+GMP_VER := 6.2.1
+GMP_CHKSUM := sha-256=fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2
+GMP_URL = https://ftp.gnu.org/gnu/gmp/gmp-$(1).tar.xz \
 
-MPFR_VER = 4.1.0
-MPFR_CHKSUM = sha-256=0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f
+MPFR_VER := 4.1.0
+MPFR_CHKSUM := sha-256=0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f
 MPFR_REQS := gmp
+MPFR_URL = https://ftp.gnu.org/gnu/mpfr/mpfr-$(1).tar.xz
 
-XML2_VER = 2.9.10
-XML2_CHKSUM = sha-256=aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f
+XML2_VER := 2.9.10
+XML2_CHKSUM := sha-256=aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f
+XML2_URL = http://xmlsoft.org/sources/libxml2-$(1).tar.gz
+
+GNUPLOT_VER := 5.4.1
+GNUPLOT_CHKSUM := sha-256=6b690485567eaeb938c26936e5e0681cf70c856d273cc2c45fabf64d8bc6590e
+GNUPLOT_URL = https://downloads.sourceforge.net/project/gnuplot/gnuplot/$(1)/gnuplot-$(1).tar.gz
 
 .PHONY: serve default
 default: serve
 
+download_tarball = \
+    aria2c $(if $($(1)_CHKSUM),--check-integrity=true) --auto-file-renaming=false \
+		$(call $(1)_URL,$($(1)_VER)) --out=$@ $(if $($(1)_CHKSUM),--checksum=$($(1)_CHKSUM))
+lib/libqalculate.tar.gz:
+	$(call download_tarball,QALCULATE)
 lib/emsdk.tar.gz:
-	aria2c --check-integrity=true --auto-file-renaming=false \
-	    https://github.com/emscripten-core/emsdk/archive/$(EMSDK_VER).tar.gz \
-	    --out=lib/emsdk.tar.gz \
-	    --checksum=$(EMSDK_CHKSUM)
+	$(call download_tarball,EMSDK)
 lib/gmp.tar.xz:
-	aria2c --check-integrity=true --auto-file-renaming=false \
-	    https://ftp.gnu.org/gnu/gmp/gmp-$(GMP_VER).tar.xz \
-	    --out=lib/gmp.tar.xz \
-	    --checksum=$(GMP_CHKSUM)
+	$(call download_tarball,GMP)
 lib/mpfr.tar.xz:
-	aria2c --check-integrity=true --auto-file-renaming=false \
-	    https://ftp.gnu.org/gnu/mpfr/mpfr-$(MPFR_VER).tar.xz \
-	    --out=lib/mpfr.tar.xz \
-	    --checksum=$(MPFR_CHKSUM)
+	$(call download_tarball,MPFR)
 lib/libxml2.tar.gz:
-	aria2c --check-integrity=true --auto-file-renaming=false \
-	    http://xmlsoft.org/sources/libxml2-$(XML2_VER).tar.gz \
-	    --out=lib/libxml2.tar.gz \
-	    --checksum=$(XML2_CHKSUM)
+	$(call download_tarball,XML2)
+lib/gnuplot.tar.gz:
+	$(call download_tarball,GNUPLOT)
 
+untar = tar xmf $< -C $(@D) && rm -rf $@ && mv $@-* $@
 lib/emsdk: lib/emsdk.tar.gz
-	pushd lib
-	tar xf emsdk.tar.gz
-	mv emsdk-* emsdk
-	popd
+	$(untar)
 lib/gmp: lib/gmp.tar.xz
-	pushd lib
-	tar xf gmp.tar.xz
-	mv gmp-* gmp
-	popd
-lib/libqalculate:
-	mkdir -p lib
-	pushd lib
-	git clone https://github.com/Qalculate/libqalculate.git
-	cd libqalculate
-	git reset --hard v$(QALCULATE_VER)
-	popd
+	$(untar)
+lib/libqalculate: lib/libqalculate.tar.gz
+	$(untar)
 lib/mpfr: lib/mpfr.tar.xz
-	pushd lib
-	tar xf mpfr.tar.xz
-	mv mpfr-* mpfr
-	popd
+	$(untar)
 lib/libxml2: lib/libxml2.tar.gz
-	pushd lib
-	tar xf libxml2.tar.gz
-	mv libxml2-* libxml2
-	popd
+	$(untar)
+lib/gnuplot: lib/gnuplot.tar.gz
+	$(untar)
 
 ACTIVATE_EMSDK := lib/emsdk/upstream/.emsdk_version
 EMSDK_ENV := . lib/emsdk/emsdk_env.sh >/dev/null 2>&1
@@ -90,57 +82,71 @@ $(ACTIVATE_EMSDK): | lib/emsdk
 	$|/emsdk install $(EMSDK_VER)
 	$|/emsdk activate $(EMSDK_VER)
 
+CD_BUILDDIR = mkdir -p $(@D) && cd $(@D)
 lib/build/libxml2/Makefile: $(ACTIVATE_EMSDK) $(call libreqs,XML2) | lib/libxml2
 	$(EMSDK_ENV)
-	mkdir -p lib/build/libxml2
-	cd lib/build/libxml2
+	$(CD_BUILDDIR)
 	emconfigure ../../libxml2/configure --host none --prefix="$(PREFIX)" \
 	    --with-minimum --with-sax1 --with-tree --with-output
 lib/build/gmp/Makefile: $(ACTIVATE_EMSDK) $(call libreqs,GMP) | lib/gmp
 	$(EMSDK_ENV)
-	mkdir -p lib/build/gmp
-	cd lib/build/gmp
+	$(CD_BUILDDIR)
 	emconfigure ../../gmp/configure --host none --prefix="$(PREFIX)" \
 		--disable-assembly --disable-cxx --disable-fft \
 		--enable-alloca=notreentrant
 lib/build/mpfr/Makefile: $(ACTIVATE_EMSDK) $(call libreqs,MPFR) | lib/mpfr
 	$(EMSDK_ENV)
-	mkdir -p lib/build/mpfr
-	cd lib/build/mpfr
+	$(CD_BUILDDIR)
 	emconfigure ../../mpfr/configure --host none --prefix="$(PREFIX)" \
 		--disable-thread-safe --enable-decimal-float=no \
 		--with-gmp=$(PREFIX)
 lib/build/libqalculate/Makefile: $(ACTIVATE_EMSDK) $(call libreqs,QALCULATE) | lib/libqalculate
 	$(EMSDK_ENV)
-	mkdir -p lib/build/libqalculate
-	cd lib/build/libqalculate
-	NOCONFIGURE=true ../../libqalculate/autogen.sh
+	$(CD_BUILDDIR)
+	[[ -f ../../libqalculate/configure ]] || NOCONFIGURE=true ../../libqalculate/autogen.sh
 	CFLAGS="-I$(PREFIX)/include" LDFLAGS="-L$(PREFIX)/lib" \
 	LIBXML_CFLAGS="-I$(PREFIX)/include/libxml2" LIBXML_LIBS="$(LDFLAGS)" \
 	    emconfigure ../../libqalculate/configure \
-	        --host none --prefix="$(PREFIX)" \
-		    --without-libcurl --without-icu --disable-textport --disable-nls --without-gnuplot-call \
+	        --build "$$(../../libqalculate/config.guess)" --host none --prefix="$(PREFIX)" \
+		    --without-libcurl --without-icu --disable-textport --disable-nls --with-gnuplot-call=byo \
 		    --enable-compiled-definitions
-
-$(LIBDIR)/libxml2.a: $(ACTIVATE_EMSDK) lib/build/libxml2/Makefile
+lib/build/gnuplot/Makefile: $(ACTIVATE_EMSDK) $(call libreqs,GNUPLOT) | lib/gnuplot
 	$(EMSDK_ENV)
-	$(MAKE) -C lib/build/libxml2 CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" PROGRAMS= install
+	$(CD_BUILDDIR)
+	emconfigure ../../gnuplot/configure \
+		--host none --prefix="$(PREFIX)" \
+		--without-readline --without-x --disable-h3d-quadtree --disable-wxwidgets
 
-$(LIBDIR)/libgmp.a: $(ACTIVATE_EMSDK) lib/build/gmp/Makefile
-	$(EMSDK_ENV)
-	$(MAKE) -C lib/build/gmp CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" install
+submake = $(MAKE) -C $(<D) CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+make_lib = $(submake) install
 
-$(LIBDIR)/libmpfr.a: $(ACTIVATE_EMSDK) lib/build/mpfr/Makefile
+$(LIBDIR)/libxml2.a: lib/build/libxml2/Makefile
 	$(EMSDK_ENV)
-	$(MAKE) -C lib/build/mpfr CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" install
+	$(make_lib) PROGRAMS=''
 
-$(LIBDIR)/libqalculate.a: $(ACTIVATE_EMSDK) lib/build/libqalculate/Makefile
+$(LIBDIR)/libgmp.a: lib/build/gmp/Makefile
 	$(EMSDK_ENV)
-	$(MAKE) -C lib/build/libqalculate CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" install
+	$(make_lib)
+
+$(LIBDIR)/libmpfr.a: lib/build/mpfr/Makefile
+	$(EMSDK_ENV)
+	$(make_lib)
+
+$(LIBDIR)/libqalculate.a: lib/build/libqalculate/Makefile
+	$(EMSDK_ENV)
+	$(make_lib)
+
+lib/build/gnuplot/src/gnuplot lib/build/gnuplot/src/gnuplot.wasm &: lib/build/gnuplot/Makefile
+	$(EMSDK_ENV)
+	$(submake) gnuplot
+build/gnuplot.js: lib/build/gnuplot/src/gnuplot
+	cp $< $@
+build/gnuplot.wasm: lib/build/gnuplot/src/gnuplot.wasm
+	cp $< $@
 
 OBJS = $(patsubst src/%.cpp,src/%.o,$(wildcard src/*.cpp))
 
-src/%.o: src/%.cpp $(ACTIVATE_EMSDK) $(LIBDIR)/libqalculate.a
+src/%.o: src/%.cpp $(LIBDIR)/libqalculate.a
 	$(EMSDK_ENV)
 	emcc --bind $(CXXFLAGS) -Oz -c $< -o $@
 
@@ -158,7 +164,8 @@ build/qalc.js: $(OBJS) $(call libfiles,$(LIBNAMES))
 	    -o build/qalc.js
 build/qalc.wasm: build/qalc.js
 
-PUBLIC_FILES = build/qalc.js build/qalc.wasm src/index.html src/main.js src/style.css src/favicon.png
+PUBLIC_FILES = build/qalc.js build/qalc.wasm build/gnuplot.js build/gnuplot.wasm \
+               src/index.html src/main.js src/gnuplot-worker.js src/style.css src/favicon.png
 
 serve: deploy
 	python3 -m http.server -d public 8000

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ SHELL := /bin/bash
 ROOT_DIR := $(PWD)
 PREFIX := $(ROOT_DIR)/lib/install
 CFLAGS := -I$(PREFIX)/include -O3 -flto --profiling
-CXXFLAGS := $(CFLAGS) -fno-rtti -fno-exceptions -std=c++11 -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0
-LDFLAGS := -L$(PREFIX)/lib -flto
+CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions -std=c++11 -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0
+LDFLAGS := -L$(PREFIX)/lib -flto -fno-rtti -Oz -gseparatedwarf --source-map-base http://localhost:8000
 
 prepend = $(foreach a,$(2),$(1)$(a))
 libfiles = $(foreach lib,$(1),$(LIBDIR)/lib$(lib).a)
@@ -15,11 +15,11 @@ LIBDIR := lib/install/lib
 LIBNAMES := gmp mpfr xml2 qalculate
 libreqs = $(call libfiles,$($(1)_REQS))
 
-QALCULATE_VER := 3.15.0
-# QALCULATE_CHKSUM := sha-256=ed6752cdc6fe6ffc444844e130820d720feba746f98447259117102f6196b216
+QALCULATE_VER := 4092c3c900728bb336b3f189dcab531fae33d7f2
+QALCULATE_CHKSUM := sha-256=e7724621acd3efddeeb23f0f91a40fb0d9f10de4e7b2e7efae6ae3b09c240c9c
 QALCULATE_REQS := gmp mpfr xml2
 # QALCULATE_URL = https://github.com/Qalculate/libqalculate/releases/download/v$(1)/libqalculate-$(1).tar.gz
-QALCULATE_URL = https://github.com/coolreader18/libqalculate/archive/byo-gnuplot.tar.gz
+QALCULATE_URL = https://github.com/Qalculate/libqalculate/archive/$(1).tar.gz
 
 EMSDK_VER := 2.0.11
 EMSDK_CHKSUM := sha-256=f366c569d10b5eedf56edab86f4e834ca3a5ca0bf4f9ab1818d8575afd10277b
@@ -118,7 +118,7 @@ lib/build/gnuplot/Makefile: $(ACTIVATE_EMSDK) $(call libreqs,GNUPLOT) | lib/gnup
 		--host none --prefix="$(PREFIX)" \
 		--without-readline --without-x --disable-h3d-quadtree --disable-wxwidgets
 
-submake = $(MAKE) -C $(<D) CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+submake = $(MAKE) -C $(<D) CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)"
 make_lib = $(submake) install
 
 $(LIBDIR)/libxml2.a: lib/build/libxml2/Makefile
@@ -137,13 +137,14 @@ $(LIBDIR)/libqalculate.a: lib/build/libqalculate/Makefile
 	$(EMSDK_ENV)
 	$(make_lib)
 
+lib/build/gnuplot/src/gnuplot lib/build/gnuplot/src/gnuplot.wasm &: CFLAGS += -Oz
 lib/build/gnuplot/src/gnuplot lib/build/gnuplot/src/gnuplot.wasm &: lib/build/gnuplot/Makefile
 	$(EMSDK_ENV)
 	$(submake) gnuplot
 build/gnuplot.js: lib/build/gnuplot/src/gnuplot
-	cp $< $@
+	mkdir -p $(@D) && cp $< $@
 build/gnuplot.wasm: lib/build/gnuplot/src/gnuplot.wasm
-	cp $< $@
+	mkdir -p $(@D) && cp $< $@
 
 OBJS = $(patsubst src/%.cpp,src/%.o,$(wildcard src/*.cpp))
 
@@ -151,19 +152,16 @@ src/%.o: src/%.cpp $(LIBDIR)/libqalculate.a
 	$(EMSDK_ENV)
 	emcc --bind $(CXXFLAGS) -Oz -c $< -o $@
 
-build/qalc.js: $(OBJS) $(call libfiles,$(LIBNAMES))
+build/qalc.js build/qalc.wasm &: $(OBJS) $(call libfiles,$(LIBNAMES))
 	$(EMSDK_ENV)
-	mkdir -p build
+	mkdir -p $(@D)
 	emcc \
-	    --bind -fno-rtti \
+	    --bind \
 	    $(LDFLAGS) \
-	    --source-map-base http://localhost:8000 \
-	    -Oz -gseparatedwarf \
 	    -s WARN_UNALIGNED=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s FILESYSTEM=0 \
 	    $(call prepend,-l,$(LIBNAMES)) \
 	    $(OBJS) \
 	    -o build/qalc.js
-build/qalc.wasm: build/qalc.js
 
 PUBLIC_FILES = build/qalc.js build/qalc.wasm build/gnuplot.js build/gnuplot.wasm \
                src/index.html src/main.js src/gnuplot-worker.js src/style.css src/favicon.png

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ MPFR_CHKSUM := sha-256=0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c9
 MPFR_REQS := gmp
 MPFR_URL = https://ftp.gnu.org/gnu/mpfr/mpfr-$(1).tar.xz
 
-XML2_VER := 2.9.10
-XML2_CHKSUM := sha-256=aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f
+XML2_VER := 2.9.12
+XML2_CHKSUM := sha-256=c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92
 XML2_URL = http://xmlsoft.org/sources/libxml2-$(1).tar.gz
 
 GNUPLOT_VER := 5.4.1
@@ -86,6 +86,7 @@ CD_BUILDDIR = mkdir -p $(@D) && cd $(@D)
 lib/build/libxml2/Makefile: $(ACTIVATE_EMSDK) $(call libreqs,XML2) | lib/libxml2
 	$(EMSDK_ENV)
 	$(CD_BUILDDIR)
+	NOCONFIGURE=true ../../libxml2/autogen.sh
 	emconfigure ../../libxml2/configure --host none --prefix="$(PREFIX)" \
 	    --with-minimum --with-sax1 --with-tree --with-output
 lib/build/gmp/Makefile: $(ACTIVATE_EMSDK) $(call libreqs,GMP) | lib/gmp

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -1,5 +1,6 @@
 #include <libqalculate/qalculate.h>
 #include <emscripten/bind.h>
+#include <emscripten/val.h>
 
 using namespace emscripten;
 
@@ -10,6 +11,19 @@ Calculator* getCalculator() {
         new Calculator();
     }
     return CALCULATOR;
+}
+
+std::string qalc_gnuplot_data_dir() {
+    return "";
+}
+bool qalc_invoke_gnuplot(
+    std::vector<std::pair<std::string, std::string>> data_files,
+    std::string commands, std::string extra, bool persist) {
+    val data_obj = val::object();
+    for (auto file : data_files) {
+        data_obj.set(file.first, file.second);
+    }
+    return val::global("runGnuplot").call<bool>("call", val::undefined(), data_obj, commands, extra, persist);
 }
 
 EMSCRIPTEN_BINDINGS(calculator_bindings) {

--- a/src/gnuplot-worker.js
+++ b/src/gnuplot-worker.js
@@ -1,0 +1,55 @@
+let pendingRequests = [];
+
+self.addEventListener('message', ({ data }) => {
+    if (pendingRequests) {
+        // gnuplot not loaded yet
+        pendingRequests.push(data);
+    } else {
+        doPlot(data);
+    }
+});
+
+var Module = {
+    noInitialRun: true,
+    postRun: () => {
+        shouldRunNow = true;
+        pendingRequests.forEach(doPlot);
+        pendingRequests = null;
+    },
+    print: (s) => {
+        console.log('GNUPLOT LOG: ' + s);
+    },
+    printErr: (s) => {
+        console.warn('GNUPLOT ERR: ' + s);
+    },
+};
+
+function doPlot({
+    fix_cmd = true,
+    data_files = {},
+    commands,
+    id,
+    // TODO: do something with these...?
+    extra_commandline,
+    persist,
+}) {
+    const files = Object.keys(data_files);
+    for (const [file, data] of Object.entries(data_files)) {
+        FS.writeFile(file, data);
+    }
+    const cmd = fix_cmd
+        ? commands.replace(
+              'set terminal pop',
+              "set terminal svg; set output '/output'"
+          )
+        : commands;
+    FS.writeFile('/commands', cmd);
+    callMain(['/commands']);
+    const output = FS.readFile('/output', { encoding: 'utf8' });
+    for (const file of ['/commands', '/output', ...files]) {
+        FS.unlink(file);
+    }
+    self.postMessage({ id, output });
+}
+
+importScripts('gnuplot.js');

--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,8 @@
       WASM. At the moment, currencies are not supported, as they require
       external resources.</p>
 
+    <p>Plotting works, try <code>plot(3x^2; -10; 10)</code></p>
+
     <p>The source code for this tool <a
         href="https://github.com/flaviut/qalculate-wasm">can be found on
         GitHub</a></p>

--- a/src/index.html
+++ b/src/index.html
@@ -34,6 +34,11 @@
             <div class="cell-result"></div>
         </div>
     </div>
+    <div class="hide" id="plot-template">
+        <div class="plot-err">
+            <h2>Unable to plot</h2>
+        </div>
+    </div>
 
     <div id="cells">
 

--- a/src/main.js
+++ b/src/main.js
@@ -89,7 +89,8 @@ let emptySvgUrl;
 let plot_id = 0;
 let gnuplotWorker;
 
-const makeSvgUrl = (data) => URL.createObjectURL(new Blob([data], { type: 'image/svg+xml' }));
+const makeSvgUrl = (data) =>
+    URL.createObjectURL(new Blob([data], { type: 'image/svg+xml' }));
 function runGnuplot(data_files, commands, extra_commandline, persist) {
     if (!gnuplotWorker) {
         gnuplotWorker = new Worker('gnuplot-worker.js');
@@ -117,34 +118,43 @@ function runGnuplot(data_files, commands, extra_commandline, persist) {
     img.id = 'plot_' + id;
     curCell.node.insertAdjacentElement('afterend', img);
 
-    gnuplotWorker.postMessage({ data_files, commands, extra_commandline, persist, id });
+    gnuplotWorker.postMessage({
+        data_files,
+        commands,
+        extra_commandline,
+        persist,
+        id,
+    });
     return true;
 }
 
 var Module = {
     postRun: () => {
-        console.time('new')
-        window.calc = new Module.Calculator()
+        console.time('new');
+        window.calc = new Module.Calculator();
         calc.loadGlobalDefinitions();
-        console.timeEnd('new')
-        console.time('calc x1000')
+        console.timeEnd('new');
+        console.time('calc x1000');
         for (let i = 0; i < 1000; i++) {
-            calc.calculateAndPrint('1+1', 1000)
+            calc.calculateAndPrint('1+1', 1000);
         }
-        console.timeEnd('calc x1000')
+        console.timeEnd('calc x1000');
 
         newCell();
     },
     print: function (text) {
-        if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+        if (arguments.length > 1)
+            text = Array.prototype.slice.call(arguments).join(' ');
         console.log(text);
     },
     printErr: function (text) {
-        if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+        if (arguments.length > 1)
+            text = Array.prototype.slice.call(arguments).join(' ');
         console.error(text);
     },
     setStatus: function (text) {
-        if (!Module.setStatus.last) Module.setStatus.last = { time: Date.now(), text: '' };
+        if (!Module.setStatus.last)
+            Module.setStatus.last = { time: Date.now(), text: '' };
         if (text === Module.setStatus.last.text) return;
         var m = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
         var now = Date.now();
@@ -159,8 +169,16 @@ var Module = {
     totalDependencies: 0,
     monitorRunDependencies: function (left) {
         this.totalDependencies = Math.max(this.totalDependencies, left);
-        Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies - left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
-    }
+        Module.setStatus(
+            left
+                ? 'Preparing... (' +
+                      (this.totalDependencies - left) +
+                      '/' +
+                      this.totalDependencies +
+                      ')'
+                : 'All downloads complete.'
+        );
+    },
 };
 Module.setStatus('Downloading...');
 window.onerror = function (event) {

--- a/src/main.js
+++ b/src/main.js
@@ -27,16 +27,16 @@ function newCell() {
     curCell.node.id = 'cell_' + cellNum;
     curCell.input.addEventListener('keydown', onKey);
     cells.append(curCell.node);
-    focusCell();
+    focusCell(curCell);
 }
 
+/** @param {Cell} cell */
 function focusCell(cell) {
-    const c = cell || curCell;
-    c.input.focus({ preventScroll: true });
-    if (c.node !== curCell.node) {
-        c.input.select();
+    cell.input.focus({ preventScroll: true });
+    if (cell.input.readOnly) {
+        cell.input.select();
     }
-    c.node.scrollIntoView({ behavior: 'smooth' });
+    cell.node.scrollIntoView({ behavior: 'smooth' });
 }
 
 /** @param {KeyboardEvent} ev */
@@ -46,11 +46,15 @@ function onKey(ev) {
     if (ev.key === 'Enter') {
         const text = inp.value;
         if (inp === curCell.input) {
-            curCell.result.textContent = calc.calculateAndPrint(text, 1000);
+            if (text.trim() !== '') {
+                curCell.result.textContent = calc.calculateAndPrint(text, 1000);
+            }
             newCell();
         } else {
-            curCell.input.value = text;
-            focusCell();
+            if (text.trim() !== '') {
+                curCell.input.value = text;
+            }
+            focusCell(curCell);
         }
     } else if (ev.key === 'ArrowUp' || ev.key === 'ArrowDown') {
         const cellNode = inp.parentElement;
@@ -95,7 +99,7 @@ function runGnuplot(data_files, commands, extra_commandline, persist) {
             if (output) {
                 plot.src = makeSvgUrl(output);
                 setTimeout(() => {
-                    focusCell();
+                    focusCell(curCell);
                 }, 10);
             } else {
                 plot.replaceWith(plotErrTmpl.cloneNode(true));

--- a/src/style.css
+++ b/src/style.css
@@ -28,3 +28,17 @@ body {
 .hide {
     display: none;
 }
+.plot {
+    display: block;
+}
+.plot-err {
+    color: red;
+    width: 600px;
+    height: 480px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+.plot-err h2 {
+    text-align: center;
+}


### PR DESCRIPTION
Depends on #3

![image](https://user-images.githubusercontent.com/33094578/119019733-19c25880-b963-11eb-8b59-edd6cb249d91.png)

The key things that enable this in libqalculate are `qalc_gnuplot_data_dir`/`qalc_invoke_gnuplot` in entry.cpp and passing `--with-gnuplot=byo` to configure, which were added in qalculate/libqalculate#281.

cc @hanna-kn, this is what I was working on with bring-your-own gnuplot.